### PR TITLE
refactor(lex): use cursor based lexer

### DIFF
--- a/Lex_bench_test.go
+++ b/Lex_bench_test.go
@@ -1,0 +1,53 @@
+package mql
+
+import (
+	"math/rand"
+	"testing"
+
+	lx "github.com/hashicorp/mql/lexer"
+)
+
+var charSet = []rune("01234567890+-*/()")
+
+func randText(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = charSet[rand.Intn(len(charSet))]
+	}
+	return string(b)
+}
+
+// the current implementation
+func BenchmarkLexerStack(b *testing.B) {
+	l := newLexer(randText(b.N))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.read()
+		l.unread()
+
+		l.read()
+		l.read()
+		l.read()
+		l.unread()
+
+		runesToString(l.current)
+		l.current.clear()
+	}
+}
+
+// the new implementation
+func BenchmarkLexerCursor(b *testing.B) {
+	l := lx.New(randText(b.N))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Shift()
+		l.Backup()
+
+		l.Shift()
+		l.Shift()
+		l.Shift()
+		l.Backup()
+
+		l.Reduce()
+	}
+}

--- a/lexer/checks.go
+++ b/lexer/checks.go
@@ -1,0 +1,56 @@
+package lexer
+
+import (
+	"strings"
+	"unicode"
+)
+
+// check if a given rune matches a given criteria
+type CheckFn func(rune) bool
+
+var (
+	IsEOF                = Eq(RuneEOF)
+	IsSpace              = unicode.IsSpace
+	IsNumber             = unicode.IsDigit
+	IsLetter             = unicode.IsLetter
+	IsDoubleQuote        = Eq('"')
+	IsArithmeticOperator = In("+-*/")
+	IsLogicSymbol        = In("&|")
+	IsParenthesisLeft    = Eq('(')
+	IsParenthesisRight   = Eq(')')
+	IsEQ                 = Eq('=')
+)
+
+func Eq(valid rune) CheckFn {
+	return func(r rune) bool { return r == valid }
+}
+
+func In(valid string) CheckFn {
+	return func(r rune) bool { return strings.ContainsRune(valid, r) }
+}
+
+func Not(valid CheckFn) CheckFn {
+	return func(r rune) bool { return !valid(r) }
+}
+
+func Or(checks ...CheckFn) CheckFn {
+	return func(r rune) bool {
+		for _, valid := range checks {
+			if valid(r) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func And(checks ...CheckFn) CheckFn {
+	return func(r rune) bool {
+		for _, valid := range checks {
+			if !valid(r) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,0 +1,129 @@
+package lexer
+
+import (
+	"errors"
+	"unicode/utf8"
+)
+
+func New(text string) *Lexer {
+	return &Lexer{buf: text}
+}
+
+type Lexer struct {
+	buf      string
+	off      int
+	lastRead readOp
+	pos      int
+	eof      bool
+}
+
+// used to track the size of the last read rune, since ut8 chars can be bigger
+// than one byte
+type readOp int8
+
+const (
+	opRead readOp = iota - 1
+	opInvalid
+	opReadRune1
+	opReadRune2
+	opReadRune3
+	opReadRune4
+)
+
+const (
+	RuneErr rune = -1
+	RuneEOF rune = 0
+)
+
+// true, if the offset is at the end of the input buffer
+func (l *Lexer) empty() bool { return len(l.buf) <= l.off }
+
+// length of unread portion of the input buffer
+func (l *Lexer) Len() int { return len(l.buf) - l.off }
+
+// offset from the start of the input buffer
+func (l *Lexer) Off() int { return l.off }
+
+func (l *Lexer) Diff(v string) int { return l.off - len(v) }
+
+// return the next rune.
+// if the input is empty, a synthetic
+// EOF rune, with value 0, is emitted and
+// the offset is not modified
+func (l *Lexer) Shift() rune {
+	if l.empty() {
+		// emit artificial eof rune
+		l.eof = true
+		l.lastRead = opReadRune1
+		return RuneEOF
+	}
+	c := l.buf[l.off]
+	if c < utf8.RuneSelf {
+		l.off++
+		l.lastRead = opReadRune1
+		return rune(c)
+	}
+	r, n := utf8.DecodeRuneInString(l.buf[l.off:])
+	l.off += n
+	l.lastRead = readOp(n)
+	return r
+}
+
+// move the offset back by the size of the last read rune.
+// only 1 backup is possible.
+// if the last rune was EOF, the offset is not actually modified
+func (l *Lexer) Backup() error {
+	if l.lastRead <= opInvalid {
+		return errors.New("UnreadRune: previous operation was not a successful ReadRune")
+	}
+	// account for artificial eof rune
+	if l.eof {
+		l.eof = false
+		return nil
+	}
+	if l.off >= int(l.lastRead) {
+		l.off -= int(l.lastRead)
+	}
+	// this prevents to backup twice, because the size of
+	// the previous rune, is not known
+	l.lastRead = opInvalid
+	return nil
+}
+
+// get the runes from the last call of Reduce
+// to the offset.
+func (l *Lexer) Reduce() string {
+	v := l.buf[l.pos:l.off]
+	l.pos = l.off
+	return string(v)
+}
+
+// get the next rune, without mutating the offset
+func (l *Lexer) Peek() rune {
+	r := l.Shift()
+	l.Backup()
+	return r
+}
+
+// advance, if the next rune passes the check
+func (l *Lexer) Expect(valid CheckFn) bool {
+	if !valid(l.Shift()) {
+		l.Backup()
+		return false
+	}
+	return true
+}
+
+// advance, for as long as subsequent runes
+// pass the check. Returns false if not at least 1
+// rune has been consumed
+func (l *Lexer) Some(valid CheckFn) bool {
+	if !valid(l.Shift()) {
+		l.Backup()
+		return false
+	}
+	for valid(l.Shift()) {
+	}
+	l.Backup()
+	return true
+}


### PR DESCRIPTION
resolve: #16 

This PR is here to show the benchmarks. Before it can potentially be merged, the old lexer needs to be removed and the new one needs to put in its place with the method names adjusted. (I took the lexer as is, from one of my own projects)

```
❯ go test -benchmem -run 'BenchmarkLexer.*' -bench  . 
goos: linux
goarch: amd64
pkg: github.com/hashicorp/mql
cpu: Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz
BenchmarkLexerStack-8           12255547                94.60 ns/op           16 B/op          2 allocs/op
BenchmarkLexerCursor-8          127588782                9.478 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/hashicorp/mql        7.804s
```

> **Warning** 
> there may be some licensing implications. See https://github.com/hashicorp/mql/pull/17#discussion_r1313936616
