### PR TITLE
test(lex): fix static check warning literalloopclosure

### DIFF
--- a/lex_test.go
+++ b/lex_test.go
@@ -161,6 +161,7 @@ func Test_lexKeywordState(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 

--- a/lex_test.go
+++ b/lex_test.go
@@ -220,6 +220,7 @@ func Test_lexWhitespaceState(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert, require := assert.New(t), require.New(t)

--- a/mql_test.go
+++ b/mql_test.go
@@ -201,6 +201,7 @@ func TestParse(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			whereClause, err := mql.Parse(tc.query, tc.model, tc.opts...)

--- a/mql_unexported_test.go
+++ b/mql_unexported_test.go
@@ -123,6 +123,7 @@ func Test_exprToWhereClause(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			whereClause, err := exprToWhereClause(tc.expr, tc.validators, tc.opt...)

--- a/parser_test.go
+++ b/parser_test.go
@@ -292,6 +292,7 @@ func Test_parser(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			p := newParser(tc.raw)

--- a/tests/postgres/postgres_test.go
+++ b/tests/postgres/postgres_test.go
@@ -58,8 +58,8 @@ func Test_postgres(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		testName := tc.name
-		t.Run(testName, func(t *testing.T) {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			where, err := mql.Parse(tc.query, user{}, tc.opts...)
 			if tc.wantErrContains != "" {


### PR DESCRIPTION
fixes `loop variable tc captured by func literalloopclosure`