### PR TITLE
refactor(options): fix static check warning S1011

### DIFF
--- a/options.go
+++ b/options.go
@@ -82,13 +82,7 @@ func WithConverter(fieldName string, fn ValidateConvertFunc) Option {
 // (your Go struct) when parsing. Note: Field names are case sensitive.
 func WithIgnoredFields(fieldName ...string) Option {
 	return func(o *options) error {
-		if len(fieldName) > 0 {
-			o.withIgnoredFields = make([]string, len(fieldName))
-			for _, name := range fieldName {
-				o.withIgnoredFields = append(o.withIgnoredFields, name)
-			}
-			o.withIgnoredFields = fieldName
-		}
+		o.withIgnoredFields = fieldName
 		return nil
 	}
 }


### PR DESCRIPTION
fixes `should replace loop with o.withIgnoredFields = append(o.withIgnoredFields, fieldName...) (S1011) go-staticcheck`

Potentially the below would be better, in case there are already ignored fields, from a somewhere else 

```go
 o.withIgnoredFields = append(o.withIgnoredFields, fieldName...)
```

Instead, I have used the following, in order to preserve the current behavior (except for the len check).

So perhaps we should clarify the desired behavior, first.
