### PR TITLE
test(unexported): fix static check warning ST1006

### DIFF
--- a/mql_unexported_test.go
+++ b/mql_unexported_test.go
@@ -154,9 +154,9 @@ func Test_fieldValidators(t *testing.T) {
 
 type invalidExpr struct{}
 
-func (_ *invalidExpr) Type() exprType {
+func (*invalidExpr) Type() exprType {
 	return unknownExprType
 }
-func (_ *invalidExpr) String() string {
+func (*invalidExpr) String() string {
 	return "unknown"
 }


### PR DESCRIPTION
Fixes `receiver name should not be an underscore, omit the name if it is unused (ST1006) go-staticcheck`