### PR TITLE
fix: multi-column queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@ Canonical reference for changes, improvements, and bugfixes for mql.
 
 ## Next
 
+## 0.1.3 (2023/12/19)
+
+* chore(deps): bump golang.org/x/crypto from 0.7.0 to 0.17.0 in /tests/postgres ([PR](https://github.com/hashicorp/mql/pull/33))
+* fix (parse): queries with multiple columns need to properly handle right-side
+  logic expressions when they are complete expressions (having both a left and
+  right side). ([PR](https://github.com/hashicorp/mql/pull/34))
+* chore: add github action to check diffs on generated bits ([PR](https://github.com/hashicorp/mql/pull/32))
+* chore: add race checker to "go test" in github action ([PR](https://github.com/hashicorp/mql/pull/31))
 * chore: add govulncheck to github actions ([PR](https://github.com/hashicorp/mql/pull/30))
-* update go matrix in CI: remove 1.18 and add 1.21 ([PR](https://github.com/hashicorp/mql/pull/30))
+* update go matrix in CI: remove 1.18 and add 1.21 ([PR](https://github.com/hashicorp/mql/pull/30)) 
 
 ## 0.1.2 (2023/09/18)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Example query:
 
 If your model contains a time.Time field, then we'll append `::date` to the
 column name when generating a where clause and the comparison value must be in
-an `ISO-8601` format. 
+an `ISO-8601` format.
 
 Note: It's possible to compare date-time fields down to the
 millisecond using `::date` and a literal in `ISO-8601` format.
@@ -97,6 +97,12 @@ provide optional validation+conversion functions for fields in your model via
 Example date comparison down to the HH::MM using an ISO-8601 format:
 
 `name="alice" and created_at>"2023-12-01 14:01"`
+
+Note: Expressions with the same level of precedence are evaluated right to left.
+Example:
+`name="alice" and age > 11 and region =
+"Boston"` is evaluated as: `name="alice" and (age > 11 and region =
+"Boston")`
 
   
 
@@ -194,10 +200,10 @@ if err != nil {
 
 ```
 
-
 ### Grammar
 
 See: [GRAMMAR.md](./GRAMMAR.md)
+
 
 ## Security
 

--- a/mql_test.go
+++ b/mql_test.go
@@ -77,6 +77,15 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:  "success-multi-columned-with-an-or",
+			query: "(name=`alice`) and (email=`eve@example.com`) or (member_number = 1)",
+			model: &testModel{},
+			want: &mql.WhereClause{
+				Condition: "(name=? and (email=? or member_number=?))",
+				Args:      []any{"alice", "eve@example.com", "1"},
+			},
+		},
+		{
 			name:  "null-string",
 			query: "name=\"null\"",
 			model: &testModel{},

--- a/mql_test.go
+++ b/mql_test.go
@@ -68,6 +68,15 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:  "success-multi-columned",
+			query: "(name=`alice`) and (email=`eve@example.com`) and (member_number = 1)",
+			model: &testModel{},
+			want: &mql.WhereClause{
+				Condition: "(name=? and (email=? and member_number=?))",
+				Args:      []any{"alice", "eve@example.com", "1"},
+			},
+		},
+		{
 			name:  "null-string",
 			query: "name=\"null\"",
 			model: &testModel{},

--- a/parser.go
+++ b/parser.go
@@ -63,6 +63,14 @@ TkLoop:
 				return nil, fmt.Errorf("%s: %w before right side expression in: %q", op, ErrMissingLogicalOp, p.raw)
 			// finally, assign the right expr
 			case logicExpr.rightExpr == nil:
+				if e.rightExpr != nil {
+					// if e.rightExpr isn't nil, then we've got a complete
+					// expr (left + op + right) and we need to assign this to
+					// our rightExpr
+					logicExpr.rightExpr = e
+					break TkLoop
+				}
+				// otherwise, we need to assign the left side of e to our
 				logicExpr.rightExpr = e.leftExpr
 				break TkLoop
 			}

--- a/parser.go
+++ b/parser.go
@@ -70,7 +70,7 @@ TkLoop:
 					logicExpr.rightExpr = e
 					break TkLoop
 				}
-				// otherwise, we need to assign the left side of e to our
+				// otherwise, we need to assign the left side of e
 				logicExpr.rightExpr = e.leftExpr
 				break TkLoop
 			}


### PR DESCRIPTION
fix (parse): queries with multiple columns need to properly handle right-side logic expressions when they are complete expressions (having both a left and right side).