### PR TITLE
support column tags for filter / column names

### DIFF
--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ import (
 type options struct {
 	withSkipWhitespace     bool
 	withColumnMap          map[string]string
+	withColumnFieldTag     string
 	withValidateConvertFns map[string]ValidateConvertFunc
 	withIgnoredFields      []string
 	withPgPlaceholder      bool
@@ -53,6 +54,19 @@ func WithColumnMap(m map[string]string) Option {
 		if !isNil(m) {
 			o.withColumnMap = m
 		}
+		return nil
+	}
+}
+
+// Add the new option function
+// WithColumnFieldTag provides an option to use a specific struct tag for field mapping
+// If a field has this tag, the tag value will be used instead of the field name
+func WithColumnFieldTag(tagName string) Option {
+	return func(o *options) error {
+		if tagName == "" {
+			return fmt.Errorf("mql.WithColumnFieldTag: empty tag name: %w", ErrInvalidParameter)
+		}
+		o.withColumnFieldTag = tagName
 		return nil
 	}
 }


### PR DESCRIPTION
This pull request introduces a new option to specify a struct tag for field mapping in the `options.go` and `validate.go` files. The most important changes include the addition of the `WithColumnFieldTag` option and the corresponding adjustments in the field validation logic.

#### New feature for field mapping:

* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R13): Added `withColumnFieldTag` to the `options` struct to store the specified tag for field mapping.
* [`options.go`](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R61-R73): Introduced the `WithColumnFieldTag` function to allow users to specify a struct tag for field mapping. This function validates the tag name and updates the `options` struct accordingly.

#### Adjustments in field validation logic:

* [`validate.go`](diffhunk://#diff-bbf4d9531c9f596bdac5b426ac47babf2ad4d4b0a2196e8f013de35ab8515886L47-R72): Modified the `fieldValidators` function to utilize the new `withColumnFieldTag` option. It now checks for the specified tag on each field and uses the tag value for mapping if present. If no tag is found or specified, it falls back to using the field name.

#### Why

Field names do not always align with db table names. Also specifying a map of column names to field names can be excessive with logs of models. This allows you to just add a tag to your DB models and have that tag represent your table name.

This is potentially easier because this tag follows your structs, but it can even use tags generated by db to struct generators. Similar to gorm.